### PR TITLE
Fix standard scale factors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,15 @@
 adms-2.3.x:
 
+ * Check scaling factors againd LRM 2.0.4
+   * Add missing K scaling (uppercase kilo)
+   * standard scale_factor T|G|M|K|k|m|u|n|p|f|a
+   * Add testset (va and xml files) to test the scaling factors
+
+ * Handle non-standard scaling factors with warning E|P|D|h|d|c|A
+   Patch by Geoffrey Coram
+
  * Relax Bison requirement, tested with (2.5, 3.0.2)
+
  * Perl GD module is no longer required at build time.
    The GD module is becoming hard to install, and it is only used to create
    a few images used on the html documentation. If images need to be changed,

--- a/adms.xml
+++ b/adms.xml
@@ -553,6 +553,7 @@
             <evalue name="T" info="multiplication factor = 1.0e+12 (tera)"/>
             <evalue name="G" info="multiplication factor = 1.0e+9  (giga)"/>
             <evalue name="M" info="multiplication factor = 1.0e+6  (mega)"/>
+            <evalue name="K" info="multiplication factor = 1.0e+3  (Kilo)"/>
             <evalue name="k" info="multiplication factor = 1.0e+3  (kilo)"/>
             <evalue name="h" info="multiplication factor = 1.0e+2  (hecto)"/>
             <evalue name="D" info="multiplication factor = 1.0e+1  (deka)"/>

--- a/admsXml/adms.implicit.xml
+++ b/admsXml/adms.implicit.xml
@@ -206,9 +206,11 @@
           <admst:value-to select="math/value" path="value"/>
         </admst:when>
         <admst:when test="[scalingunit='E']">
+          <admst:warning format="%(lexval/(f|':'|l|':'|c)): non-standard scale factor: %(scalingunit)\n"/>
           <admst:value-to select="math/value" string="%(value)e+18"/>
         </admst:when>
         <admst:when test="[scalingunit='P']">
+          <admst:warning format="%(lexval/(f|':'|l|':'|c)): non-standard scale factor: %(scalingunit)\n"/>
           <admst:value-to select="math/value" string="%(value)e+15"/>
         </admst:when>
         <admst:when test="[scalingunit='T']">
@@ -220,16 +222,22 @@
         <admst:when test="[scalingunit='M']">
           <admst:value-to select="math/value" string="%(value)e+6"/>
         </admst:when>
+        <admst:when test="[scalingunit='K']">
+          <admst:value-to select="math/value" string="%(value)e+3"/>
+        </admst:when>
         <admst:when test="[scalingunit='k']">
           <admst:value-to select="math/value" string="%(value)e+3"/>
         </admst:when>
         <admst:when test="[scalingunit='h']">
           <admst:value-to select="math/value" string="%(value)e+2"/>
+          <admst:warning format="%(lexval/(f|':'|l|':'|c)): non-standard scale factor: %(scalingunit)\n"/>
         </admst:when>
         <admst:when test="[scalingunit='D']">
           <admst:value-to select="math/value" string="%(value)e+1"/>
+          <admst:warning format="%(lexval/(f|':'|l|':'|c)): non-standard scale factor: %(scalingunit)\n"/>
         </admst:when>
         <admst:when test="[scalingunit='d']">
+          <admst:warning format="%(lexval/(f|':'|l|':'|c)): non-standard scale factor: %(scalingunit)\n"/>
           <admst:value-to select="math/value" string="%(value)e-1"/>
         </admst:when>
         <admst:when test="[scalingunit='c']">
@@ -245,6 +253,7 @@
           <admst:value-to select="math/value" string="%(value)e-9"/>
         </admst:when>
         <admst:when test="[scalingunit='A']">
+          <admst:warning format="%(lexval/(f|':'|l|':'|c)): non-standard scale factor: %(scalingunit)\n"/>
           <admst:value-to select="math/value" string="%(value)e-10"/>
         </admst:when>
         <admst:when test="[scalingunit='p']">

--- a/admsXml/verilogaYacc.y.in
+++ b/admsXml/verilogaYacc.y.in
@@ -220,6 +220,7 @@ R_s.nature_assignment
           _ else if(!strcmp(mylexval4,"T")) myunit=admse_T;
           _ else if(!strcmp(mylexval4,"G")) myunit=admse_G;
           _ else if(!strcmp(mylexval4,"M")) myunit=admse_M;
+          _ else if(!strcmp(mylexval4,"K")) myunit=admse_K;
           _ else if(!strcmp(mylexval4,"k")) myunit=admse_k;
           _ else if(!strcmp(mylexval4,"h")) myunit=admse_h;
           _ else if(!strcmp(mylexval4,"D")) myunit=admse_D;
@@ -1466,6 +1467,7 @@ R_e.atomic
           _ else if(!strcmp(mylexval2,"T")) myunit=admse_T;
           _ else if(!strcmp(mylexval2,"G")) myunit=admse_G;
           _ else if(!strcmp(mylexval2,"M")) myunit=admse_M;
+          _ else if(!strcmp(mylexval2,"K")) myunit=admse_K;
           _ else if(!strcmp(mylexval2,"k")) myunit=admse_k;
           _ else if(!strcmp(mylexval2,"h")) myunit=admse_h;
           _ else if(!strcmp(mylexval2,"D")) myunit=admse_D;
@@ -1496,6 +1498,7 @@ R_e.atomic
           _ else if(!strcmp(mylexval2,"T")) myunit=admse_T;
           _ else if(!strcmp(mylexval2,"G")) myunit=admse_G;
           _ else if(!strcmp(mylexval2,"M")) myunit=admse_M;
+          _ else if(!strcmp(mylexval2,"K")) myunit=admse_K;
           _ else if(!strcmp(mylexval2,"k")) myunit=admse_k;
           _ else if(!strcmp(mylexval2,"h")) myunit=admse_h;
           _ else if(!strcmp(mylexval2,"D")) myunit=admse_D;

--- a/tescases/0000_scale_factor.va
+++ b/tescases/0000_scale_factor.va
@@ -1,0 +1,47 @@
+
+// scale_factor ::= T|G|M|K|k|m|u|n|p|f|a
+
+// non-standard  E P D h d c A
+
+module scaling();
+ parameter integer itera  = 1T;
+ parameter integer igiga  = 1G;
+ parameter integer imega  = 1M;
+ parameter integer iKilo  = 1K;
+ parameter integer ikilo  = 1k;
+ parameter integer imili  = 1m;
+ parameter integer imicro = 1u;
+ parameter integer inano  = 1n;
+ parameter integer ipico  = 1p;
+ parameter integer ifemto = 1f;
+ parameter integer iatto  = 1a;
+
+ parameter integer iexa      = 1E;
+ parameter integer ipeta     = 1P;
+ parameter integer ihecto    = 1h;
+ parameter integer ideca     = 1D;
+ parameter integer ideci     = 1d;
+ parameter integer icenti    = 1c;
+ parameter integer iamgstron = 1A;
+
+ parameter real tera  = 1.0T;
+ parameter real giga  = 1.0G;
+ parameter real mega  = 1.0M;
+ parameter real Kilo  = 1.0K;
+ parameter real kilo  = 1.0k;
+ parameter real mili  = 1.0m;
+ parameter real micro = 1.0u;
+ parameter real nano  = 1.0n;
+ parameter real pico  = 1.0p;
+ parameter real femto = 1.0f;
+ parameter real atto  = 1.0a;
+
+ parameter real exa      = 1.0E;
+ parameter real peta     = 1.0P;
+ parameter real hecto    = 1.0h;
+ parameter real deca     = 1.0D;
+ parameter real deci     = 1.0d;
+ parameter real centi    = 1.0c;
+ parameter real amgstron = 1.0A;
+
+endmodule

--- a/tescases/0000_scale_factor.xml
+++ b/tescases/0000_scale_factor.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!DOCTYPE admst SYSTEM "admst.dtd">
+
+<admst version="2.3.5">
+
+  <!-- handle number element -->
+  <admst:template match=":number">
+
+    <!-- check type -->
+    <admst:if test="[cast='i']">
+        <admst:variable name="cast" select="int"/> <!-- store -->
+    </admst:if>
+    <admst:if test="[cast='d']">
+        <admst:variable name="cast" select="double"/> <!-- store -->
+    </admst:if>
+
+    <!-- pretty print value and scaling -->
+    <admst:value-of select="value"/>
+    <admst:choose>
+      <admst:when test="[scalingunit='1']">%s</admst:when>
+
+      <admst:when test="[scalingunit='T']">$(cast) %se12</admst:when>
+      <admst:when test="[scalingunit='G']">$(cast) %se+9</admst:when>
+      <admst:when test="[scalingunit='M']">$(cast) %se+6</admst:when>
+      <admst:when test="[scalingunit='K']">$(cast) %se+3</admst:when>
+      <admst:when test="[scalingunit='k']">$(cast) %se+3</admst:when>
+      <admst:when test="[scalingunit='m']">$(cast) %se-3</admst:when>
+      <admst:when test="[scalingunit='u']">$(cast) %se-6</admst:when>
+      <admst:when test="[scalingunit='n']">$(cast) %se-9</admst:when>
+      <admst:when test="[scalingunit='p']">$(cast) %se-12</admst:when>
+      <admst:when test="[scalingunit='f']">$(cast) %se-15</admst:when>
+      <admst:when test="[scalingunit='a']">$(cast) %se-18</admst:when>
+
+      <admst:when test="[scalingunit='E']">$(cast) %se+18</admst:when>
+      <admst:when test="[scalingunit='P']">$(cast) %se+15</admst:when>
+      <admst:when test="[scalingunit='h']">$(cast) %se+2</admst:when>
+      <admst:when test="[scalingunit='D']">$(cast) %se+1</admst:when>
+      <admst:when test="[scalingunit='d']">$(cast) %se-1</admst:when>
+      <admst:when test="[scalingunit='c']">$(cast) %se-2</admst:when>
+      <admst:when test="[scalingunit='A']">$(cast) %se-10</admst:when>
+
+      <admst:otherwise>
+        <admst:value-of select="scalingunit"/>
+        <admst:fatal format="%s%s: scaling unit not supported\n"/>
+      </admst:otherwise>
+    </admst:choose>
+  </admst:template>
+
+  <!-- handle default element  -->
+  <admst:template match=":expression">
+    <!-- get type of data -->
+    <admst:value-of select="tree/adms/datatypename"/>
+    <admst:variable name="type" select="%s"/> <!-- store -->
+    <admst:text format="\t$(type) "/>
+    <admst:apply-templates select="tree" match=":$(type)" required="yes"/>
+  </admst:template>
+
+  <!-- loop over modules -->
+  <admst:for-each select="/module">
+
+    <!-- print module name -->
+    <admst:value-of select="./name" />
+    <admst:text format="module : %s\n"/>
+
+      <!-- print name of variables, type and its default value -->
+      <admst:for-each select="variable">
+        <admst:value-of select="./name" />
+        <admst:text format="variable : %s  " />
+        <admst:apply-templates select="default" match=":expression"/>
+        <admst:text format="\n" />
+      </admst:for-each>
+
+  </admst:for-each>  <!-- module -->
+
+</admst>
+
+


### PR DESCRIPTION
Warn about non conformal scaling units. 
https://sourceforge.net/p/mot-adms/bugs/17/

There is still an issue the 'K' factor. It seems not to parse it properly if used like '1K'. Using '1.0K' is fine. Working on it.

The test should print:

```
~/git/adms/tescases $ ../admsXml/admsXml 0000_scale_factor.va -e 0000_scale_factor.xml 
[info...] admsXml-2.3.5 (deedba5) Jan 15 2015 11:15:31
[warning] ./0000_scale_factor.va:19:27: non-standard scale factor: E
[warning] ./0000_scale_factor.va:20:27: non-standard scale factor: P
[warning] ./0000_scale_factor.va:21:27: non-standard scale factor: h
[warning] ./0000_scale_factor.va:22:27: non-standard scale factor: D
[warning] ./0000_scale_factor.va:23:27: non-standard scale factor: d
[warning] ./0000_scale_factor.va:25:27: non-standard scale factor: A
module : scaling
variable : tera  	[type] number [value] 1e12
variable : giga  	[type] number [value] 1e+9
variable : mega  	[type] number [value] 1e+6
variable : Kilo  	[type] number [value] 1.e+3
variable : kilo  	[type] number [value] 1e+3
variable : mili  	[type] number [value] 1e-3
variable : micro  	[type] number [value] 1e-6
variable : nano  	[type] number [value] 1e-9
variable : pico  	[type] number [value] 1e-12
variable : femto  	[type] number [value] 1e-15
variable : atto  	[type] number [value] 1e-18
variable : exa  	[type] number [value] 1e+18
variable : peta  	[type] number [value] 1e+15
variable : hecto  	[type] number [value] 1e+2
variable : deca  	[type] number [value] 1e+1
variable : deci  	[type] number [value] 1e-1
variable : centi  	[type] number [value] 1e-2
variable : amgstron  	[type] number [value] 1e-10
[info...] elapsed time: 0 (second)
[info...] admst iterations: 4104 (2158 freed)

```