### PR TITLE
standard compliant paramlist parser

### DIFF
--- a/admsXml/admsVeriloga.h
+++ b/admsXml/admsVeriloga.h
@@ -84,4 +84,10 @@ win32_interface void verilogaerror (const char *s);
 win32_interface int verilogalex ();
 win32_interface int verilogaparse ();
 
+typedef enum {
+	ctx_any,
+	ctx_moduletop
+} e_verilogactx;
+e_verilogactx verilogactx ();
+
 #endif /* _admsveriloga_h */

--- a/admsXml/mkelements.pl
+++ b/admsXml/mkelements.pl
@@ -1136,6 +1136,8 @@ foreach(@$EA)
       $adms_c.="}\n";
     }
     #lookup
+	 # BUG. linear search has linear runtime.
+	 # use proper containers!!1
     if(
       (($ename =~ "admsmain")&&($xname =~ "discipline"))
       ||

--- a/admsXml/verilogaLex.l
+++ b/admsXml/verilogaLex.l
@@ -253,3 +253,5 @@ INF {TKRETURN(yytext,yyleng); return tk_inf;}
 %%
 
 int yywrap (void) {return 1;}
+
+// vim:sw=2:ts=8:noet:

--- a/admsXml/verilogaLex.l
+++ b/admsXml/verilogaLex.l
@@ -233,7 +233,17 @@ exclude {TKRETURN(yytext,yyleng); return tk_exclude;}
 inf {TKRETURN(yytext,yyleng); return tk_inf;}
 INF {TKRETURN(yytext,yyleng); return tk_inf;}
 
-{ident} {TKRETURN(yytext,yyleng); return tk_ident;}
+{ident} {
+  TKRETURN(yytext,yyleng);
+  switch (verilogactx()){
+    case ctx_moduletop:
+      if (adms_admsmain_list_discipline_lookup_by_id(root(),yytext)) {
+	return tk_disc_id;
+      }
+    default:
+      return tk_ident;
+  }
+}
 
 \>\> {TKRETURN(yytext,yyleng); return tk_op_shr;}
 \<\< {TKRETURN(yytext,yyleng); return tk_op_shl;}

--- a/admsXml/verilogaYacc.y.in
+++ b/admsXml/verilogaYacc.y.in
@@ -1119,12 +1119,16 @@ R_s.case.item
           _ mycaseitem->_defaultcase=admse_yes;
           _ Y($$,(p_adms)mycaseitem);
         ;
+R_s.paramlist.0
+        |
+        | '#' '(' R_l.instance.parameter ')'
+       ;
 R_s.instance
-        | R_instance.module.name '#' '(' R_l.instance.parameter ')' tk_ident '(' R_l.node ')' ';'
+        | R_instance.module.name R_s.paramlist.0 tk_ident '(' R_l.node ')' ';'
           _ p_instance myinstance;
           _ p_slist l1;
           _ p_slist l2;
-          _ myinstance=adms_module_list_instance_prepend_by_id_once_or_abort(gModule,gModule,gInstanceModule,mylexval6);
+          _ myinstance=adms_module_list_instance_prepend_by_id_once_or_abort(gModule,gModule,gInstanceModule,mylexval3);
           _ adms_slist_inreverse(&gInstanceModule->_node);
           _ l2=gInstanceModule->_node;
           _ l2=l2->next; /*GND ignored*/

--- a/admsXml/verilogaYacc.y.in
+++ b/admsXml/verilogaYacc.y.in
@@ -608,17 +608,16 @@ R_l.analogfunction.real.variable
           _   myvariableprototype->_type=admse_real;
           _ }
         ;
-R_variable.type
-        | tk_integer R_d.attribute.0
+R_variable.type.set
+        | tk_integer
           _ gVariableType=admse_integer;
-          _ adms_slist_concat(&gGlobalAttributeList,gAttributeList);
-          _ gAttributeList=NULL;
-        | tk_real R_d.attribute.0
+        | tk_real
           _ gVariableType=admse_real;
-          _ adms_slist_concat(&gGlobalAttributeList,gAttributeList);
-          _ gAttributeList=NULL;
-        | tk_string R_d.attribute.0
+        | tk_string
           _ gVariableType=admse_string;
+        ;
+R_variable.type
+        | R_variable.type.set R_d.attribute.0
           _ adms_slist_concat(&gGlobalAttributeList,gAttributeList);
           _ gAttributeList=NULL;
         ;
@@ -1522,25 +1521,16 @@ R_e.atomic
           _ Y($$,(p_adms)adms_string_new(mylexval1));
         | tk_ident
           _ $$=adms_yaccval_new("unknown source file");
-          _ if(gAnalogfunction)
+          _ p_variable myvariable=variable_recursive_lookup_by_id(gBlockList->data,$1);
+          _ if(myvariable)
+          _   Y($$,(p_adms)myvariable);
+          _ else if (!gAnalogfunction)
           _ {
-          _   p_variable myvariable=variable_recursive_lookup_by_id(gBlockList->data,$1);
-          _   if(myvariable)
-          _     Y($$,(p_adms)myvariable);
-          _ }
-          _ else
-          _ {
-          _   p_variable myvariable=variable_recursive_lookup_by_id(gBlockList->data,$1);
-          _   if(myvariable)
-          _     Y($$,(p_adms)myvariable);
-          _   else
-          _   {
           _     p_branchalias mybranchalias=adms_module_list_branchalias_lookup_by_id(gModule,gModule,mylexval1);
           _     p_node mynode=adms_module_list_node_lookup_by_id(gModule,gModule,mylexval1);
           _     if(mynode) Y($$,(p_adms)mynode);
           _     if(mybranchalias)
           _       Y($$,(p_adms)mybranchalias->_branch);
-          _   }
           _ }
           _ if(!YY($$))
           _   adms_veriloga_message_fatal("identifier never declared\n",$1);

--- a/admsXml/verilogaYacc.y.in
+++ b/admsXml/verilogaYacc.y.in
@@ -5,6 +5,10 @@
 #define YYDEBUG 1
 #include "admsVeriloga.h"
 
+static e_verilogactx ctx;
+e_verilogactx verilogactx (){return ctx;}
+void set_context(e_verilogactx x){ctx=x;}
+
 #define NEWVARIABLE(l) p_variableprototype myvariableprototype=adms_variableprototype_new(gModule,l,(p_adms)gBlockList->data);
 
 inline static void   Y (p_yaccval myyaccval,p_adms myusrdata) {myyaccval->_usrdata=myusrdata;}

--- a/admsXml/verilogaYacc.y.in
+++ b/admsXml/verilogaYacc.y.in
@@ -18,6 +18,7 @@ static p_number gNatureAbsTol=NULL;
 static char* gNatureUnits=NULL;
 static char* gNatureidt=NULL;
 static char* gNatureddt=NULL;
+static char* gDisc=NULL;
 static p_discipline gDiscipline=NULL;
 static p_module gModule=NULL;
 static p_analogfunction gAnalogfunction=NULL;
@@ -308,7 +309,9 @@ R_d.module
           _ for(l=gAttributeList;l;l=l->next)
           _   adms_slist_push(&gModule->_attribute,l->data);
           _ adms_slist_free(gAttributeList); gAttributeList=NULL;
-        R_d.terminal R_modulebody tk_endmodule
+        R_d.terminal
+          _ set_context(ctx_moduletop);
+        R_modulebody tk_endmodule
           _ adms_slist_pull(&gBlockList);
           _ adms_slist_inreverse(&gModule->_assignment);
         ;
@@ -357,8 +360,10 @@ R_l.declaration
         ;
 R_s.declaration.withattribute
         | R_s.declaration
+          _ set_context(ctx_moduletop);
         | R_d.attribute.global R_s.declaration
           _ adms_slist_free(gGlobalAttributeList); gGlobalAttributeList=NULL;
+          _ set_context(ctx_moduletop);
         ;
 R_d.attribute.global
         | R_d.attribute
@@ -368,26 +373,39 @@ R_d.attribute.global
 R_s.declaration
         | R_d.node
         | R_d.branch
-        | tk_parameter R_variable.type R_l.parameter R_d.variable.end
-        | tk_parameter R_l.parameter R_d.variable.end
-        | R_variable.type R_l.variable R_d.variable.end
+        | tk_parameter
+          _ set_context(ctx_any);
+        R_variable.type R_l.parameter R_d.variable.end
+        | tk_parameter
+          _ set_context(ctx_any);
+        R_l.parameter R_d.variable.end
+        | R_variable.type
+          _ set_context(ctx_any);
+        R_l.variable R_d.variable.end
         | R_d.aliasparameter
         | R_d.analogfunction
         | ';'
         ;
 R_d.node
-        | R_node.type R_l.terminalnode  ';'
+        | R_node.type
+          _ set_context(ctx_any);
+        R_l.terminalnode  ';'
           _ p_slist l;
           _ for(l=gTerminalList;l;l=l->next)
           _   ((p_node)l->data)->_direction=gNodeDirection;
           _ adms_slist_free(gTerminalList); gTerminalList=NULL;
-        | tk_ground R_l.node  ';'
+        | tk_ground
+          _ set_context(ctx_any);
+        R_l.node  ';'
           _ p_slist l;
           _ for(l=gNodeList;l;l=l->next)
           _   ((p_node)l->data)->_location=admse_ground;
           _ adms_slist_free(gNodeList); gNodeList=NULL;
-        | tk_ident R_l.node ';'
-          _ char* mydisciplinename=mylexval1;
+        | tk_disc_id
+          _ set_context(ctx_any);
+          _ gDisc=mylexval1;
+        R_l.node ';'
+          _ char* mydisciplinename=gDisc;
           _ p_discipline mydiscipline=adms_admsmain_list_discipline_lookup_by_id(root(),mydisciplinename);
           _ p_slist l;
           _ for(l=gNodeList;l;l=l->next)
@@ -621,7 +639,9 @@ R_variable.type.set
           _ gVariableType=admse_string;
         ;
 R_variable.type
-        | R_variable.type.set R_d.attribute.0
+        | R_variable.type.set
+          _ set_context(ctx_any);
+        R_d.attribute.0
           _ adms_slist_concat(&gGlobalAttributeList,gAttributeList);
           _ gAttributeList=NULL;
         ;
@@ -797,8 +817,11 @@ R_interval.sup
           _ Y($$,(p_adms)myexpression);
         ;
 R_analog
-        | tk_analog R_analogcode
-          _ gModule->_analog=adms_analog_new(YY($2));
+        | tk_analog
+          _ set_context(ctx_any); // from here, don't recognize node declarations.
+          _                       // they are not permitted anyway.
+          R_analogcode
+          _ gModule->_analog=adms_analog_new(YY($R_analogcode));
         ;
 R_analogcode
         | R_analogcode.atomic
@@ -1118,6 +1141,8 @@ R_s.instance
         ;
 R_instance.module.name
         | tk_ident
+          _ set_context(ctx_any); // from here, don't recognize node declarations.
+          _                       // they are not permitted anyway.
           _ gInstanceModule=adms_admsmain_list_module_lookup_by_id(root(),mylexval1);
           _ if(!gInstanceModule)
           _   adms_message_fatal(("module '%s' not found\n",mylexval1));


### PR DESCRIPTION
the parser for parameter lists in subdevice instanciation is wrong. unfortunately, the grammar defined by the standard is context sensitive, hence a few more commits.
