### PR TITLE
set class to "operator" for {d,i}dt operators in global list

### DIFF
--- a/admsXml/adms.implicit.xml
+++ b/admsXml/adms.implicit.xml
@@ -165,14 +165,16 @@
           name='\$realtime' or
           name='\$temperature' or
           name='\$vt' or
-          name='idt' or
-          name='ddt' or
           name='\$param_given' or
           name='\$given' or
           name='ddx' or
           name='flicker_noise' or
           name='white_noise'
           ]">
+        </admst:when>
+        <admst:when test="[name='idt' or name='ddt']">
+          <admst:push into="$globalexpression/function" select="."/>
+          <admst:value-to select="class" string="operator"/>
         </admst:when>
 
         <!-- Table 4-14 - Standard Functions -->


### PR DESCRIPTION
operators are simply not builtin functions. they should be accessible individually, as they may need different code to be generated.