### PR TITLE
Update bison

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,11 +14,18 @@ install:
   # CMake refuses to generate MinGW Makefiles if Git's sh.exe is in the PATH
   - del "%ProgramFiles(x86)%\Git\bin\sh.exe"
 
+  # Need bison-2.5+, 
+  # Get if form chocolatey\bin, already in front of Git\bin (which has bison-2.4.1)
+  - choco install -y winflexbison 
+  - mv C:\ProgramData\chocolatey\bin\win_bison.exe C:\ProgramData\chocolatey\bin\bison.exe
+  - mv C:\ProgramData\chocolatey\bin\win_flex.exe C:\ProgramData\chocolatey\bin\flex.exe
+
   # Add MinGW to path
   - path  C:\MinGW\bin;%PATH%
   - gcc --version
   - flex --version
   - bison --version
+  - where bison
 
 build_script:
   - mkdir cmake_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,9 @@ if ( USE_MAINTAINER_MODE )
 endif ( USE_MAINTAINER_MODE )
 
 
-find_package(BISON)
+find_package(BISON 2.5)
 
 # handle api.prefix, unused for the moment
-MESSAGE("BISON_VERSION ${BISON_VERSION}")
 IF (${BISON_VERSION} VERSION_LESS "2.6")
   SET (BISON_APIPREFIX "-p")
 ELSE (${BISON_VERSION} VERSION_LESS "2.6")

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,11 @@ AC_ARG_VAR([FLEX], [Path to Flex lexical analyser generator])
 AC_PATH_PROG([BISON], [bison])
 AC_PATH_PROG([FLEX], [flex])
 
+bison_req=2.5
+AX_PROG_BISON_VERSION([${bison_req}], [], [
+  AC_MSG_ERROR([need $BISON >= $bison_req, found $bison_version])
+])
+
 #advice use of gcc
 AX_COMPILER_VENDOR
 if test "x$ax_cv_c_compiler_vendor" != "xgnu"; then

--- a/m4/ax_prog_bison_version.m4
+++ b/m4/ax_prog_bison_version.m4
@@ -1,0 +1,69 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_prog_bison_version.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_BISON_VERSION([VERSION],[ACTION-IF-TRUE],[ACTION-IF-FALSE])
+#
+# DESCRIPTION
+#
+#   Makes sure that bison version is greater or equal to the version
+#   indicated. If true the shell commands in ACTION-IF-TRUE are executed. If
+#   not the shell commands in commands in ACTION-IF-TRUE are executed. If
+#   not the shell commands in ACTION-IF-FALSE are run. Note if $BISON is not
+#   set (for example by running AC_CHECK_PROG or AC_PATH_PROG) the macro
+#   will fail.
+#
+#   Example:
+#
+#     AC_PATH_PROG([BISON],[bison])
+#     AX_PROG_BISON_VERSION([3.0.2],[ ... ],[ ... ])
+#
+#   This will check to make sure that the bison you have is at least version
+#   3.0.2 or greater.
+#
+#   NOTE: This macro uses the $BISON variable to perform the check.
+#
+# LICENSE
+#
+#   Copyright (c) 2015 Jonathan Rajotte-Julien <jonathan.rajotte-julien@efficios.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_PROG_BISON_VERSION],[
+    AC_REQUIRE([AC_PROG_SED])
+    AC_REQUIRE([AC_PROG_GREP])
+
+    AS_IF([test -n "$BISON"],[
+        ax_bison_version="$1"
+
+        AC_MSG_CHECKING([for bison version])
+        changequote(<<,>>)
+        bison_version=`$BISON --version 2>&1 \
+          | $SED -n -e '/bison (GNU Bison)/b inspect
+b
+: inspect
+s/.* (\{0,1\}\([0-9]*\.[0-9]*\.[0-9]*\))\{0,1\}.*/\1/;p'`
+        changequote([,])
+        AC_MSG_RESULT($bison_version)
+
+	AC_SUBST([BISON_VERSION],[$bison_version])
+
+        AX_COMPARE_VERSION([$bison_version],[ge],[$ax_bison_version],[
+	    :
+            $2
+        ],[
+	    :
+            $3
+        ])
+    ],[
+        AC_MSG_WARN([could not find bison])
+        $3
+    ])
+])


### PR DESCRIPTION
Bump bison to version 2.5+ to enable the use of named referenced tokens.