### PR TITLE
fix two implicit rules bugs related to subdevices

### DIFF
--- a/admsXml/adms.implicit.xml
+++ b/admsXml/adms.implicit.xml
@@ -552,10 +552,12 @@
   </admst:for-each>
   <admst:for-each select="instance">
     <admst:push into="module/instantiator" select=".." onduplicate="ignore"/>
-    <admst:assert select="terminal" test="nodefrommodule[location='external']"
+    <admst:assert select="terminal" test="terminal[nodefrommodule/location='external']"
                   format="%(../instantiator).%(nodefrommodule/name): is not terminal\n"/>
-    <admst:assert select="parameterset" test="parameter[input='yes']"
-                  format="%(../instantiator).%(parameter/name): is not input parameter\n"/>
+    <admst:if test="[count(parameterset)!=0]">
+      <admst:assert select="parameterset" test="parameterset[parameter/input='yes']"
+                    format="%(../instantiator).%(parameter/name): is not input parameter\n"/>
+    </admst:if>
   </admst:for-each>
   <admst:apply-templates select="(analogfunction/tree)|(analog/code)" match="dependency"/>
   <admst:for-each select="variable">

--- a/testcases/0003_subdev.va
+++ b/testcases/0003_subdev.va
@@ -1,0 +1,38 @@
+// testing subdevice instanciation
+`include "discipline.h"
+
+module net(p, n);
+	inout p, n;
+	electrical p, n;
+
+// BUG: cannot instanciate subdevices without params.
+	parameter real dummy=1 from [0:inf);
+
+	analog begin
+		begin
+			V(p, n) <+ 0;
+		end
+	end
+endmodule
+
+module RESISTOR(p, n);
+	inout p, n;
+	electrical p, n;
+
+	parameter real r=1 from [0:inf);
+	analog begin
+		begin
+			I(p, n) <+ V(p, n) / r;
+		end
+	end
+endmodule
+
+module schematic(pp, nn);
+	inout pp, nn;
+	electrical pp, nn;
+	electrical p_int, n_int;
+
+	net #(.dummy(0)) n1(p, p_int);
+	net #(.dummy(0)) n2(n, n_int);
+	RESISTOR #(.r(1)) r1(pp, nn);
+endmodule


### PR DESCRIPTION
this is required to expose the bug fixed in #28.

(could be merged into unstable, but theres no unstable yet.)
