### PR TITLE
possible analogfunction bug

### DIFF
--- a/admsXml/adms.implicit.xml
+++ b/admsXml/adms.implicit.xml
@@ -144,6 +144,9 @@
     </admst:when>
     <admst:when test="[datatypename='function']">
       <admst:if test="[definition/datatypename='analogfunction']">
+        <!-- probably not intended (crashes)
+             how to get hold of analogfunctions in assignment/rhs? -->
+        <admst:push into="$globalexpression/function" select="." onduplicate="ignore"/>
         <admst:variable name="function" select="%(.)"/>
         <admst:for-each select="definition/variable[(output='yes') and name!=$function/name]">
           <admst:variable name="p" select="%(position(.))"/>


### PR DESCRIPTION
need to access analogfunction calls on right hand sides of assignments and
contributions. this patch pushes these calls into rhs/function.

indeed, that seems to be working in

<admst:for-each select="rhs/function">
  <admst:message format="rhs function %(.)\n"/>
</admst:for-each>

but i get "admst transform unexpected" in

<admst:for-each select="rhs/function">
  <admst:apply-templates select="." match="something"/>
</admst:for-each>