### PR TITLE
Remove the Maintainer mode

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ build_script:
 
   ## Build
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./bootstrap.sh"
-  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./configure --enable-maintainer-mode --prefix=/c/adms-win%MBITS% --disable-shared"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./configure --prefix=/c/adms-win%MBITS% --disable-shared"
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make distcheck"
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make install"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,13 @@ script:
   - case $BUILD_SYSTEM in
       autotools)
         ./bootstrap.sh &&
-        ./configure --enable-maintainer-mode --prefix=/usr &&
+        ./configure --prefix=/usr &&
         make distcheck &&
         sudo make install
         ;;
       cmake)
         mkdir build && cd build &&
-        cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DUSE_MAINTAINER_MODE=ON &&
+        cmake .. -DCMAKE_INSTALL_PREFIX=/usr &&
         make &&
         sudo make install
         ;;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,6 @@ SET(PACKAGE_NAME "adms")
 SET(PACKAGE_VERSION "2.3.6")
 SET(PACKAGE_BUGREPORT "qucs-bugs@lists.sourceforge.net")
 
-OPTION ( USE_MAINTAINER_MODE "Enable generation of code (parser source) from Perl scripts." OFF )
-
 # Default to static libs ( shared needs work, BUG with MinGW). 
 OPTION ( BUILD_STATIC_LIBS "Build static libraries." ON )
 IF ( MINGW )
@@ -54,20 +52,18 @@ CHECK_FUNCTION_EXISTS (putenv HAVE_PUTENV)
 
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
-# Only care about Perl in case maintainer needs to recreate sources
+# Perl is used to recreate sources
 # * mkelements.pl
 # * mktext.pl
 # * mkgrammar.pl
-if ( USE_MAINTAINER_MODE )
-  # Checking for perl modules requires FindPerlModules.cmake
-  # Check all required modules at once
-  SET(CMAKE_MODULE_PATH "${ADMS_SOURCE_DIR}/cmake/modules")
-  include(FindPerlModules)
-  find_package(PerlModules COMPONENTS XML::LibXML)
-  if(NOT PERLMODULES_FOUND)
-    message(FATAL_ERROR "Not all required perl modules were found on your system")
-  endif(NOT PERLMODULES_FOUND)
-endif ( USE_MAINTAINER_MODE )
+# Checking for perl modules requires FindPerlModules.cmake
+# Check all required modules at once
+SET(CMAKE_MODULE_PATH "${ADMS_SOURCE_DIR}/cmake/modules")
+include(FindPerlModules)
+find_package(PerlModules COMPONENTS XML::LibXML)
+if(NOT PERLMODULES_FOUND)
+  message(FATAL_ERROR "Not all required perl modules were found on your system")
+endif(NOT PERLMODULES_FOUND)
 
 
 find_package(BISON 2.5)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ADMS is known to work on these platforms.
 - GNU Flex
 - GNU Bison (tested with 2.5+)
 - GNU Libtool
-- Perl with XML::LibXml (only for maintainers)
+- Perl with XML::LibXml
   - GD modules to manually update documentation images
 
 Installing dependencies on Linux Debian/Ubuntu:
@@ -58,34 +58,30 @@ This section is relevant in case ADMS is compiled from the Git repository.
 
 #### Compilation Using Autotools
 
-The `--enable-maintainer-mode` makes sure the required files are generated (using Perl and LibXml).
+Use the default commands to compile, generate files and install.
 
     sh bootstrap.sh
-    ./configure --enable-maintainer-mode
+    ./configure
     make install
 
 Autotools it currently used for creating release packages, the `adms-x.x.x.tar.gz` source code archive.
 
     sh bootstrap.sh
-    ./configure --enable-maintainer-mode
+    ./configure
     make clean
     make dist
 
 #### Compilation Using CMake
 
-The `-DUSE_MAINTAINER_MODE=ON` makes sure the required files are generated (using Perl and LibXml).
-
     mkdir cmake; cd cmake
-    cmake .. -DUSE_MAINTAINER_MODE=ON -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=/install/location/
+    cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=/install/location/
     make install
 
 Packaging is not yet supported with CMake. At the moment, only static libraries can be build with CMake.
 
-
 ### Users Install from Tarball
 
 This section is relevant in case ADMS is compiled from a source code archive (`adms-x.x.x.tar.gz`).
-Users should be able to build without Perl (and the maintainer required modules XML::LibXml and GD).
 
 #### Compilation Using Autotools
 
@@ -189,9 +185,9 @@ Original author's build instructions: (for posterity)
   3- run: libtoolize --force --ltdl -c (create libltdl and config.guess, config.sub, ltmain.sh in auxconf)
   4- run: automake -a -c (create missing, mkinstalldirs, install-sh in auxconf and all Makefile.in)
   5- run: autoconf (create configure)
-  6- run: ./configure --enable-maintainer-mode
+  6- run: ./configure
   In three shots:
     rm -rf auxconf && autoheader && mkdir auxconf && aclocal && libtoolize --force --ltdl -c
     touch ChangeLog && automake -a -c && autoconf
-    ./configure --enable-maintainer-mode
+    ./configure
 ```

--- a/admsXml/CMakeLists.txt
+++ b/admsXml/CMakeLists.txt
@@ -22,81 +22,77 @@ INCLUDE_DIRECTORIES( ${CMAKE_BINARY_DIR} ) # for config.h
 INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR} ) # for admsPreprocessor.h, amdsVeriloga.h
 INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_BINARY_DIR} ) # for generated source code
 
-# Maintainer mode runs the Perl scrips that generate source code
-if ( USE_MAINTAINER_MODE )
+# Run the Perl scrips to generate source code
+# Run mkelements.pl
+#   Read in `adms.xml` and generete portions of adms and admst
+# Generate outputs:
+#    adms.h
+#    adms.c
+#    admstpathYacc.y
+#    admstpathYacc.h
+#    admstpath.dtd
+MESSAGE(STATUS "Running mkelements.pl code generator")
 
-  # Run mkelements.pl
-  #   Read in `adms.xml` and generete portions of adms and admst
-  # Generate outputs:
-  #    adms.h
-  #    adms.c
-  #    admstpathYacc.y
-  #    admstpathYacc.h
-  #    admstpath.dtd
-  MESSAGE(STATUS "Running mkelements.pl code generator")
+EXECUTE_PROCESS(
+  COMMAND perl ${CMAKE_SOURCE_DIR}/admsXml/mkelements.pl ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        RESULT_VARIABLE element_result )
 
-  EXECUTE_PROCESS(
-    COMMAND perl ${CMAKE_SOURCE_DIR}/admsXml/mkelements.pl ${CMAKE_SOURCE_DIR}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          RESULT_VARIABLE element_result )
-
-  IF(element_result EQUAL 0)
-    MESSAGE(STATUS "mkelement.pl completed successfully")
-  ELSE(element_result EQUAL 0)
-    MESSAGE(FATAL_ERROR "mkelement.pl failed. Exit code: ${element_result}")
-  ENDIF(element_result EQUAL 0)
+IF(element_result EQUAL 0)
+  MESSAGE(STATUS "mkelement.pl completed successfully")
+ELSE(element_result EQUAL 0)
+  MESSAGE(FATAL_ERROR "mkelement.pl failed. Exit code: ${element_result}")
+ENDIF(element_result EQUAL 0)
 
 
-  # Run mkctext.pl
-  #   Wrap source files as C code
-  # Generate outputs:
-  #    constants.vams.c
-  #    disciplines.vams.c
-  #    adms.implicit.xml.c
-  #    dummy.va.c
-  #    dummy.xml.c
-  SET(CTEXT
-    constants.vams
-    disciplines.vams
-    adms.implicit.xml
-    dummy.va
-    dummy.xml )
+# Run mkctext.pl
+#   Wrap source files as C code
+# Generate outputs:
+#    constants.vams.c
+#    disciplines.vams.c
+#    adms.implicit.xml.c
+#    dummy.va.c
+#    dummy.xml.c
+SET(CTEXT
+  constants.vams
+  disciplines.vams
+  adms.implicit.xml
+  dummy.va
+  dummy.xml )
 
-  FOREACH( inc ${CTEXT} )
-    MESSAGE(STATUS "Running mkctext.pl code generator on ${inc}")
-
-    EXECUTE_PROCESS(
-      COMMAND perl ${CMAKE_CURRENT_SOURCE_DIR}/mkctext.pl ${CMAKE_CURRENT_SOURCE_DIR}/${inc}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      RESULT_VARIABLE text_result )
-
-    IF(text_result EQUAL 0)
-      MESSAGE(STATUS "mkctext.pl completed successfully")
-    ELSE(text_result EQUAL 0)
-      MESSAGE(FATAL_ERROR "mkctext.pl failed. Exit code: ${text_result}")
-    ENDIF(text_result EQUAL 0)
-  ENDFOREACH()
-
-
-  # Run mkgrammar.pl
-  #   Process verilogaYacc.y.in and generate the parser
-  # Generate output:
-  #    verilogaYacc.y
-  #
-  MESSAGE(STATUS "Running mkgrammar.pl code generator")
+FOREACH( inc ${CTEXT} )
+  MESSAGE(STATUS "Running mkctext.pl code generator on ${inc}")
 
   EXECUTE_PROCESS(
-    COMMAND perl ${CMAKE_CURRENT_SOURCE_DIR}/mkgrammar.pl ${CMAKE_CURRENT_SOURCE_DIR}/verilogaYacc.y.in
+    COMMAND perl ${CMAKE_CURRENT_SOURCE_DIR}/mkctext.pl ${CMAKE_CURRENT_SOURCE_DIR}/${inc}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          RESULT_VARIABLE grammar_result )
+    RESULT_VARIABLE text_result )
 
-  IF(grammar_result EQUAL 0)
-    MESSAGE(STATUS "mkgrammar.pl completed successfully")
-  ELSE(grammar_result EQUAL 0)
-    MESSAGE(FATAL_ERROR "mkgrammar.pl failed. Exit code: ${grammar_result}")
-  ENDIF(grammar_result EQUAL 0)
+  IF(text_result EQUAL 0)
+    MESSAGE(STATUS "mkctext.pl completed successfully")
+  ELSE(text_result EQUAL 0)
+    MESSAGE(FATAL_ERROR "mkctext.pl failed. Exit code: ${text_result}")
+  ENDIF(text_result EQUAL 0)
+ENDFOREACH()
 
-ENDIF ( USE_MAINTAINER_MODE )
+
+# Run mkgrammar.pl
+#   Process verilogaYacc.y.in and generate the parser
+# Generate output:
+#    verilogaYacc.y
+#
+MESSAGE(STATUS "Running mkgrammar.pl code generator")
+
+EXECUTE_PROCESS(
+  COMMAND perl ${CMAKE_CURRENT_SOURCE_DIR}/mkgrammar.pl ${CMAKE_CURRENT_SOURCE_DIR}/verilogaYacc.y.in
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        RESULT_VARIABLE grammar_result )
+
+IF(grammar_result EQUAL 0)
+  MESSAGE(STATUS "mkgrammar.pl completed successfully")
+ELSE(grammar_result EQUAL 0)
+  MESSAGE(FATAL_ERROR "mkgrammar.pl failed. Exit code: ${grammar_result}")
+ENDIF(grammar_result EQUAL 0)
 
 # Issue with flex:
 #   BISON_TARGET, FLEX_TARGET and ADD_FLEX_BISON_DEPENDENCY

--- a/admsXml/Makefile.am
+++ b/admsXml/Makefile.am
@@ -10,12 +10,6 @@ SUFFIXES=.vams .vams.c .va .va.c .xml .xml.c .y.in
 # use mkctext.pl to create C files containing the contents of each input file
 # in a C character array. The output is used by make check only
 
-# Perl XML::LibXml module are only required for maintainer
-# Parser created by maintainer
-# BUG: these rules are also required when building from git.
-# workaround: default to maintainer mode when building from git.
-if MAINTAINER_MODE
-
 $(incfilec):%.c:% ${srcdir}/mkctext.pl
 	$(PERL) ${srcdir}/mkctext.pl $< $(top_srcdir)
 
@@ -24,8 +18,6 @@ admstpathYacc.y admstpathYacc.h adms.h adms.c: ${top_srcdir}/adms.xml ${top_srcd
 
 verilogaYacc.y: ${srcdir}/verilogaYacc.y.in ${srcdir}/mkgrammar.pl
 	$(PERL) ${srcdir}/mkgrammar.pl ${srcdir}/verilogaYacc.y.in
-
-endif
 
 dist_man_MANS = admsXml.1 admsCheck.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -26,16 +26,8 @@ LT_INIT
 AM_INIT_AUTOMAKE([foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-# Maintainer mode is used to detect/run Perl (XML::LibXml) and make dist tarball
-AM_MAINTAINER_MODE
-
 AC_CHECK_PROG(GIT,git,yes)
 AC_MSG_CHECKING([for git repo])
-AS_IF([test x"$GIT" = "xyes" && test -d $srcdir/.git],
-   [have_git_repo=yes
-    AM_MAINTAINER_MODE([enable])],
-   [have_git_repo=no])
-AC_MSG_RESULT([$have_git_repo])
 
 AX_PROG_FLEX([],[AC_MSG_WARN(Program flex not found (found $LEX))
                  AC_MSG_ERROR(Please install gnu flex from http://www.gnu.org/software/flex/)])
@@ -97,18 +89,15 @@ AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL
 AC_SUBST([LIBTOOL_DEPS])
 
-dnl Perl, XML::LibXML module required for maintainer
-if test $USE_MAINTAINER_MODE = yes; then
+dnl Perl, XML::LibXML module required
+AC_PATH_PROG(PERL, perl, :)
+if test "$PERL" = ":"; then
+    AC_MSG_ERROR([The $PACKAGE package requires an installed perl.])
+fi;
 
-  AC_PATH_PROG(PERL, perl, :)
-  if test "$PERL" = ":"; then
-      AC_MSG_ERROR([The $PACKAGE package requires an installed perl.])
-  fi;
-
-  AX_PERL_MODULE_VERSION([XML::LibXML 2],[],[
-      AC_MSG_RESULT(failed)
-      AC_MSG_ERROR([Perl package XML::LibXML may be downloaded from http://search.cpan.org/dist/libXML])])
-fi
+AX_PERL_MODULE_VERSION([XML::LibXML 2],[],[
+    AC_MSG_RESULT(failed)
+    AC_MSG_ERROR([Perl package XML::LibXML may be downloaded from http://search.cpan.org/dist/libXML])])
 
 # Define preprocessor flag for static build (MinGW).
 AS_IF([test "x$enable_shared" = "xno"], [
@@ -130,8 +119,6 @@ AC_MSG_RESULT([ $PACKAGE version $VERSION configured successfully.])
 AC_MSG_RESULT([
 Configure Information:
   Host : $host
-
-  Maintainer mode : $USE_MAINTAINER_MODE
 
   C Compiler : $CC
   DEFS       :   $DEFS


### PR DESCRIPTION
The maintainer option which default value was false have been removed. Now it is how the user always pass the maintainer_options as on/true/yes.
Two bugs are closed with this pull request: #57 and #63 . The first bug is about download the adms...tar.gz and type make two times with the autotools build, this way the second make doesn't finish complying about a missing file. In the second bug the user forget to include -DUSE_MAINTAINER_MODE=ON which generates a build error.

One draw back of this implementation is that the perl should be always available. If you are building in Windows, it could be a disadvantage. But I think the advantages are much better than the disadvantage.

The documentation were also update. I don't change anything in the changelog.

I'm here and will try to correct anything pointed to be changed.