### PR TITLE
Make the build reproducible

### DIFF
--- a/admsXml/mkelements.pl
+++ b/admsXml/mkelements.pl
@@ -1884,7 +1884,7 @@ foreach(@$EA)
   }
   push @Location03,"  ENDIFIDENT\n";
 }
-foreach(keys(%A))
+foreach(sort keys(%A))
 {
   my($aname,$ee)=($_,$A{$_});
   push @Location03,"  IFIDENT($aname)\n";

--- a/admsXml/mkgrammar.pl
+++ b/admsXml/mkgrammar.pl
@@ -71,7 +71,7 @@ while(<>)
     die "bisonrule should terminate with ';' - see $_" if(not m/^\s+;$/);
   }
 }
-map {print OFH "\%token <_lexval> $_\n";} keys %Token;
+map {print OFH "\%token <_lexval> $_\n";} sort keys %Token;
 print OFH "\n";
 map {print OFH "\%type <_yaccval> $_->{name}\n";} @allbisonrule;
 print OFH "\n";


### PR DESCRIPTION
Whilst working on the (Reproducible Builds effort](https://reproducible-builds.org/), we noticed that ADMS could not be built reproducibly.

This is because it generated ordered C code from a grammar definition and this process was non-deterministic in nature.

This was originally filed in Debian as [#926298](https://bugs.debian.org/926298).