### PR TITLE
Propagate probe and variable dependencies into analog function output variables

### DIFF
--- a/admsXml/adms.implicit.xml
+++ b/admsXml/adms.implicit.xml
@@ -36,6 +36,8 @@
 <admst:variable name="globalopdependent" string="no"/>
 <admst:variable name="globalpartitionning"/>
 <admst:variable name="globaltreenode"/>
+<admst:variable name="globalhandleafoutputs" string="no"/>
+<admst:variable name="globalaf"/>
 
 <admst:template match="e:dependency">
   <admst:choose>
@@ -71,6 +73,9 @@
     <admst:when test="[datatypename='probe']">
       <admst:value-to select="dependency" string="linear"/>
       <admst:push into="$globalexpression/probe" select="." onduplicate="ignore"/>
+      <admst:if test="[$globalhandleafoutputs='yes']">
+        <admst:push into="$globalaf/@probe" select="." onduplicate="ignore"/>
+      </admst:if>
     </admst:when>
     <admst:when test="[datatypename='array']">
       <admst:apply-templates select="variable" match="e:dependency"/>
@@ -81,6 +86,12 @@
       <admst:push into="$globalexpression/variable" select="." onduplicate="ignore"/>
       <admst:push into="$globaltreenode/@variable" select="." onduplicate="ignore"/>
       <admst:value-to select="dependency" path="prototype/dependency"/>
+
+      <admst:if test="[$globalhandleafoutputs='yes']">
+        <admst:push into="$globalaf/@probe" select="probe" onduplicate="ignore"/>
+        <admst:push into="$globalaf/@variable" select="." onduplicate="ignore"/>
+      </admst:if>
+
     </admst:when>
     <admst:when test="[datatypename='mapply_unary']">
       <admst:apply-templates select="arg1" match="e:dependency"/>
@@ -160,7 +171,32 @@
           <admst:value-to select="dependency" string="constant"/>
         </admst:when>
         <admst:otherwise>
+          <!-- track dependencies of analog function output arguments -->
+          <admst:if test="[definition/datatypename='analogfunction']">
+            <admst:variable name="function" select="%(.)"/>
+            <admst:if test="[exists(definition/variable[(output='yes') and (name!=$function/name)])]">
+              <admst:variable name="globalhandleafoutputs" string="yes"/>
+              <admst:variable name="globalaf" path="."/>
+            </admst:if>
+          </admst:if>
+          <!-- process arguments normally -->
           <admst:apply-templates select="arguments" match="e:dependency"/>
+          <!-- propagate dependencies into output arguments -->
+          <admst:if test="[$globalhandleafoutputs='yes']">
+            <admst:variable name="globalhandleafoutputs" string="no"/>
+            <admst:variable name="globalaf"/>
+            <admst:for-each select="definition/variable">
+              <admst:if test="[(output='yes') and (name!=$function/name)]">
+                <admst:variable name="position" select="%(position(.)-1)"/>
+                <admst:fatal test="[$function/arguments[position(.)=$position]/datatypename!='variable']"
+                             format="%(function/name) output arg $position is %(.), must be a variable\n"/>
+                <admst:push into="$function/arguments[position(.)=$position]/probe" select="$function/@probe" onduplicate="ignore"/>
+                <admst:push into="$function/arguments[position(.)=$position]/variable" select="$function/@variable" onduplicate="ignore"/>
+              </admst:if>
+            </admst:for-each>
+            <admst:value-to select="$function/@probe"/>
+            <admst:value-to select="$function/@variable"/>
+          </admst:if>
           <admst:choose>
             <admst:when test="[(name='ddt' or name='\$ddt')or(name='idt' or name='\$idt')]">
               <admst:value-to select="dependency" string="nonlinear"/>

--- a/admsXml/adms.implicit.xml
+++ b/admsXml/adms.implicit.xml
@@ -193,6 +193,20 @@
                 <admst:push into="$function/arguments[position(.)=$position]/probe" select="$function/@probe" onduplicate="ignore"/>
                 <admst:push into="$function/arguments[position(.)=$position]/variable" select="$function/@variable" onduplicate="ignore"/>
                 <admst:choose>
+                  <admst:when test="$function/arguments/dependency[.='linear' or .='nonlinear']">
+                    <admst:value-to select="$function/arguments[position(.)=$position]/dependency" string="nonlinear"/>
+                    <admst:value-to select="$function/arguments[position(.)=$position]/prototype/dependency" string="nonlinear"/>
+                  </admst:when>
+                  <admst:when test="$function/arguments/dependency[.='noprobe']">
+                    <admst:value-to select="$function/arguments[position(.)=$position]/dependency" string="noprobe"/>
+                    <admst:value-to select="$function/arguments[position(.)=$position]/prototype/dependency" string="noprobe"/>
+                  </admst:when>
+                  <admst:otherwise>
+                    <admst:value-to select="$function/arguments[position(.)=$position]/dependency" string="constant"/>
+                    <admst:value-to select="$function/arguments[position(.)=$position]/prototype/dependency" string="constant"/>
+                  </admst:otherwise>
+                </admst:choose>
+                <admst:choose>
                   <admst:when test="[$globalpartitionning='initial_model']">
                     <admst:value-to select="$function/arguments[position(.)=$position]/setinmodel" string="yes"/>
                   </admst:when>

--- a/admsXml/adms.implicit.xml
+++ b/admsXml/adms.implicit.xml
@@ -192,6 +192,26 @@
                              format="%(function/name) output arg $position is %(.), must be a variable\n"/>
                 <admst:push into="$function/arguments[position(.)=$position]/probe" select="$function/@probe" onduplicate="ignore"/>
                 <admst:push into="$function/arguments[position(.)=$position]/variable" select="$function/@variable" onduplicate="ignore"/>
+                <admst:choose>
+                  <admst:when test="[$globalpartitionning='initial_model']">
+                    <admst:value-to select="$function/arguments[position(.)=$position]/setinmodel" string="yes"/>
+                  </admst:when>
+                  <admst:when test="[$globalpartitionning='initial_instance']">
+                    <admst:value-to select="$function/arguments[position(.)=$position]/setininstance" string="yes"/>
+                  </admst:when>
+                  <admst:when test="[$globalpartitionning='initial_step']">
+                    <admst:value-to select="$function/arguments[position(.)=$position]/setininitial_step" string="yes"/>
+                  </admst:when>
+                  <admst:when test="[$globalpartitionning='noise']">
+                    <admst:value-to select="$function/arguments[position(.)=$position]/setinnoise" string="yes"/>
+                  </admst:when>
+                  <admst:when test="[$globalpartitionning='final_step']">
+                    <admst:value-to select="$function/arguments[position(.)=$position]/setinfinal" string="yes"/>
+                  </admst:when>
+                  <admst:otherwise>
+                    <admst:value-to select="$function/arguments[position(.)=$position]/setinevaluate" string="yes"/>
+                  </admst:otherwise>
+                </admst:choose>
               </admst:if>
             </admst:for-each>
             <admst:value-to select="$function/@probe"/>


### PR DESCRIPTION
Per issue #67, the default implicit templates for ADMS (specifically e:dependency) do not correctly propagate probe and variable dependencies of input arguments into all output arguments.  They only do this correctly for the function return value (by propagating these dependencies into the global expression containing the analog function call).

This PR augments e:dependency so that it treats analog function output variables in much the same way that it treats the left-hand side of assignments, propagating all probe and variable dependencies, and also setting flags such as "setinmodel", "setinevaluate", etc. just as assignments do.

This should fix issue #67 and should obsolete PR #68 

I am also attaching a tarball that can be used to evaluate this PR.  It contains:
   rlc.va   -- a simple series RLC model in Verilog A
   rlc_AF.va  --- the same model, but with all computation moved down into an analog function with multiple output variables
   html_params.xml -- an ADMS "code generator" back-end that just makes an HTML file describing the module
   xyceBasicTemplates.xml --- some templates that html_params.xml uses
   two HTML files generated with html_params.xml from rlc.va and rlc_AF.va, using the fixed adms.implicit.xml file in this PR.

[ADMS_AnalogFunctionIssue2.tar.gz](https://github.com/Qucs/ADMS/files/3483109/ADMS_AnalogFunctionIssue2.tar.gz)

If one regenerates the HTML file from rlc_AF.va without using the fixes in this PR (e.g. with "admsXml -e xyceBasicTemplates -e html_params.xml rlc_AF.va"), one can see that the CapacitorCharge and InductorFlux variables are not properly marked with their dependencies on probes or parameters.  As a result of this incorrect dependency tracking, the Jacobian is missing elements as well.  Any real code generated from this model without these fixes would be wrong.  



