### PR TITLE
Update .appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,4 @@
+image: Visual Studio 2019
 environment:
   matrix:
     - MSYSTEM : MINGW64


### PR DESCRIPTION
I fork the repo and Appveyor was not able to build. It seems that the pacman version was too old (5.1.3) in the default image.
I switch to Visual Studio 2019 image for an up-to-date msys config with pacman 5.2.1.
It build successfully.