### PR TITLE
Appveyor build improvement proposition

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,8 +31,8 @@ install:
   - bash -lc ""
   - bash -lc "pacman --version"
   # Switch from SF to msys2.org (default, much faster)
-  - bash -lc "pacman --noconfirm --sync pacman-mirrors"
-  - bash -lc "pacman --noconfirm -S autoconf automake bison flex perl perl-XML-LibXML"
+  - bash -lc "pacman --noconfirm --sync --needed pacman-mirrors"
+  - bash -lc "pacman --noconfirm --sync --needed autoconf automake bison flex perl perl-XML-LibXML"
 
 build_script:
   ## Notes

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
   # Switch from SF to msys2.org (default, much faster)
   # only install missing package (--needed option)
   - bash -lc "pacman --noconfirm --sync --needed pacman-mirrors"
-  - bash -lc "pacman --noconfirm --sync --needed autoconf automake bison flex perl perl-XML-LibXML"
+  - bash -lc "pacman --noconfirm --sync --needed gcc base-devel autoconf automake bison flex perl perl-XML-LibXML"
 
 build_script:
   ## Notes

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,7 @@ build_script:
 
   ## Build
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./bootstrap.sh"
-  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./configure --prefix=/c/adms-win%MBITS% --disable-shared"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./configure --prefix=/c/adms-win%MBITS% --disable-shared --quiet"
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make distcheck"
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make install"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,7 @@ install:
   - bash -lc ""
   - bash -lc "pacman --version"
   # Switch from SF to msys2.org (default, much faster)
+  # only install missing package (--needed option)
   - bash -lc "pacman --noconfirm --sync --needed pacman-mirrors"
   - bash -lc "pacman --noconfirm --sync --needed autoconf automake bison flex perl perl-XML-LibXML"
 
@@ -42,8 +43,8 @@ build_script:
   ## Build
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./bootstrap.sh"
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && ./configure --prefix=/c/adms-win%MBITS% --disable-shared --quiet"
-  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make distcheck"
-  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make install"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make --quiet distcheck"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && make --quiet install"
 
   - bash -lc "exec 0</dev/null && /c/adms-win%MBITS%/bin/admsXml -v"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
   # Switch from SF to msys2.org (default, much faster)
   # only install missing package (--needed option)
   - bash -lc "pacman --noconfirm --sync --needed pacman-mirrors"
-  - bash -lc "pacman --noconfirm --sync --needed gcc base-devel autoconf automake bison flex perl perl-XML-LibXML"
+  - bash -lc "pacman --noconfirm --sync --needed --quiet gcc base-devel autoconf automake bison flex perl perl-XML-LibXML"
 
 build_script:
   ## Notes

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,4 @@
+image: Visual Studio 2019
 environment:
   matrix:
     - MSYSTEM : MINGW64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,18 @@ environment:
 platform:
   - x64
 
+
+skip_commits:
+  files:
+    - .travis.yml
+    - '*.md'
+
+cache:
+  # cache pacman packages
+  # max cache size is 1 GB, which should be enough
+  # but in case we could cache only mingw-w64-*-qt4-*
+  - C:\msys64\var\cache\pacman\pkg\ -> .appveyor.yml
+  
 install:
 
   # Take a look at the environment


### PR DESCRIPTION
I make some modifications in the appveyor script inspired by the qucs/qucs script:
- ``skip commit`` and ``cache``
- ``--needed`` option in pacman sync

I also added gcc and base-devel during install (not necessary for appveyor build but helpful to someone who follow the script to build on his own machine).

I add --quiet option to reduce the size of the build output. It makes it easier to spot error and warning.