### PR TITLE
Update ADMS parser to handle Accellera standard disciplines header file

### DIFF
--- a/admsXml/verilogaLex.l
+++ b/admsXml/verilogaLex.l
@@ -274,7 +274,7 @@ INF {TKRETURN(yytext,yyleng); return tk_inf;}
 \|\| {TKRETURN(yytext,yyleng); return tk_or;}
 \^\~ {TKRETURN(yytext,yyleng); return tk_bitwise_equr;}
 
-\\{ident}" " {TKRETURN(yytext,yyleng); return tk_ident;}
+\\{ident}" " {TKSTRIPPEDRETURN(yytext,yyleng); return tk_ident;}
 \${ident} {TKRETURN(yytext,yyleng); return tk_dollar_ident;}
 {char} {TKSTRIPPEDRETURN(yytext,yyleng); return tk_char;}
 {b8_int} {TKRETURN(yytext,yyleng); return tk_integer;}

--- a/admsXml/verilogaLex.l
+++ b/admsXml/verilogaLex.l
@@ -274,6 +274,7 @@ INF {TKRETURN(yytext,yyleng); return tk_inf;}
 \|\| {TKRETURN(yytext,yyleng); return tk_or;}
 \^\~ {TKRETURN(yytext,yyleng); return tk_bitwise_equr;}
 
+\\{ident}" " {TKRETURN(yytext,yyleng); return tk_ident;}
 \${ident} {TKRETURN(yytext,yyleng); return tk_dollar_ident;}
 {char} {TKSTRIPPEDRETURN(yytext,yyleng); return tk_char;}
 {b8_int} {TKRETURN(yytext,yyleng); return tk_integer;}

--- a/admsXml/verilogaYacc.y.in
+++ b/admsXml/verilogaYacc.y.in
@@ -140,6 +140,7 @@ R_s.admsParse
         ;
 R_discipline_member
         | tk_discipline R_discipline_name R_l.discipline_assignment tk_enddiscipline
+        | tk_discipline R_discipline_name ';' R_l.discipline_assignment tk_enddiscipline
           _ adms_admsmain_list_discipline_prepend_once_or_abort(root(),gDiscipline);
           _ gDiscipline=NULL;
         ;
@@ -175,6 +176,7 @@ R_discipline.naturename
 
 R_nature_member
         | tk_nature tk_ident R_l.nature_assignment tk_endnature
+        | tk_nature tk_ident ';' R_l.nature_assignment tk_endnature
           _ p_nature mynature=NULL;
           _ if(gNatureAccess) 
           _   mynature=adms_admsmain_list_nature_prepend_by_id_once_or_abort(root(),gNatureAccess);

--- a/admsXml/verilogaYacc.y.in
+++ b/admsXml/verilogaYacc.y.in
@@ -138,9 +138,12 @@ R_s.admsParse
         | R_discipline_member
         | R_nature_member
         ;
+R_optional_semicolon
+        |
+        | ';'
+        ;
 R_discipline_member
-        | tk_discipline R_discipline_name R_l.discipline_assignment tk_enddiscipline
-        | tk_discipline R_discipline_name ';' R_l.discipline_assignment tk_enddiscipline
+        | tk_discipline R_discipline_name R_optional_semicolon R_l.discipline_assignment tk_enddiscipline
           _ adms_admsmain_list_discipline_prepend_once_or_abort(root(),gDiscipline);
           _ gDiscipline=NULL;
         ;
@@ -175,8 +178,7 @@ R_discipline.naturename
         ;
 
 R_nature_member
-        | tk_nature tk_ident R_l.nature_assignment tk_endnature
-        | tk_nature tk_ident ';' R_l.nature_assignment tk_endnature
+        | tk_nature tk_ident R_optional_semicolon R_l.nature_assignment tk_endnature
           _ p_nature mynature=NULL;
           _ if(gNatureAccess) 
           _   mynature=adms_admsmain_list_nature_prepend_by_id_once_or_abort(root(),gNatureAccess);


### PR DESCRIPTION
This pull request addresses two outstanding issues preventing ADMS from being able to parse the Accellera standard disciplines header file:

1. Allow an optional semicolon after a discipline or a nature identifier in a nature and discipline declaration, respectively. This enhanced notation was introduced in v2.3.0 of the Accellera Verilog-AMS Language Reference Manual. This fixes issue #39.
2. Process escaped identifiers that can be treated as simple identifiers.
