### PR TITLE
Allow for multiple attribute instances

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -102,6 +102,7 @@
 *****-2022: 2.3.8.
             add more numerical constants
             provide constants script for more flexibility
-            fix -I, take precedence over ADMS_INCLUDEDIR
+            move ADMS_INCLUDEDIR to back of include directory search path list
             allow semicolon after identifier in disciple/nature declaration
             add basic support for escaped identifiers
+            allow for multiple attribute instances

--- a/admsXml/verilogaYacc.y.in
+++ b/admsXml/verilogaYacc.y.in
@@ -278,7 +278,11 @@ R_s.nature_assignment
         ;
 R_d.attribute.0
         |
+        | R_d.attribute.1
+        ;
+R_d.attribute.1
         | R_d.attribute
+        | R_d.attribute.1 R_d.attribute
         ;
 R_d.attribute
         | tk_beginattribute R_l.attribute tk_endattribute
@@ -370,7 +374,7 @@ R_s.declaration.withattribute
           _ set_context(ctx_moduletop);
         ;
 R_d.attribute.global
-        | R_d.attribute
+        | R_d.attribute.1
           _ gGlobalAttributeList=gAttributeList;
           _ gAttributeList=NULL;
         ;
@@ -1190,7 +1194,7 @@ R_s.assignment
           _ Y($$,(p_adms)myassignment);
           _ myvariableprototype->_vcount++;
           _ myvariableprototype->_vlast=myassignment;
-        | R_d.attribute tk_ident '=' R_s.expression
+        | R_d.attribute.1 tk_ident '=' R_s.expression
           _ p_assignment myassignment;
           _ p_variable myvariable=variable_recursive_lookup_by_id(gBlockList->data,$2);
           _ p_variableprototype myvariableprototype;
@@ -1224,7 +1228,7 @@ R_s.assignment
           _ Y($$,(p_adms)myassignment);
           _ myvariableprototype->_vcount++;
           _ myvariableprototype->_vlast=myassignment;
-        | R_d.attribute tk_ident '[' R_expression ']' '=' R_s.expression
+        | R_d.attribute.1 tk_ident '[' R_expression ']' '=' R_s.expression
           _ p_assignment myassignment;
           _ p_array myarray;
           _ p_variable myvariable=variable_recursive_lookup_by_id(gBlockList->data,$2);


### PR DESCRIPTION
Version 2.3.0 of the Verilog-AMS Language Reference Manual introduced
multiple attribute instances; e.g.,

    (* desc = "length", units = "meters", type = "model" *)

and

    (* desc = "length", units = "meters" *) (* type = "model" *)

are concidered equivalent.

Currently, ADMS can only handle the former. This commit also allows for
the latter to be used.

This is a very useful addition, given that the CMC standard macros for
defining parameters and output variables contain attribute instances;
e.g., a CMC compliant macro definition for a real model parameter with
no bounds would be as follows.

    `define MPRnb(nam, def, uni, des)\
    (* units = uni, desc = des *) parameter real nam = def

Additional attributes can now be prepended; e.g.,

    (* my_attr *) `MPRnb(l, 0.0, "meters", "length");