### PR TITLE
Allow any whitespace to end escaped identifiers

### DIFF
--- a/admsXml/verilogaLex.l
+++ b/admsXml/verilogaLex.l
@@ -274,7 +274,7 @@ INF {TKRETURN(yytext,yyleng); return tk_inf;}
 \|\| {TKRETURN(yytext,yyleng); return tk_or;}
 \^\~ {TKRETURN(yytext,yyleng); return tk_bitwise_equr;}
 
-\\{ident}{wn} {TKSTRIPPEDRETURN(yytext,yyleng); return tk_ident;} // FIXME
+\\{ident}{wn} {TKSTRIPPEDRETURN(yytext,yyleng); return tk_ident;}
 \${ident} {TKRETURN(yytext,yyleng); return tk_dollar_ident;}
 {char} {TKSTRIPPEDRETURN(yytext,yyleng); return tk_char;}
 {b8_int} {TKRETURN(yytext,yyleng); return tk_integer;}

--- a/admsXml/verilogaLex.l
+++ b/admsXml/verilogaLex.l
@@ -274,7 +274,7 @@ INF {TKRETURN(yytext,yyleng); return tk_inf;}
 \|\| {TKRETURN(yytext,yyleng); return tk_or;}
 \^\~ {TKRETURN(yytext,yyleng); return tk_bitwise_equr;}
 
-\\{ident}" " {TKSTRIPPEDRETURN(yytext,yyleng); return tk_ident;}
+\\{ident}{wn} {TKSTRIPPEDRETURN(yytext,yyleng); return tk_ident;} // FIXME
 \${ident} {TKRETURN(yytext,yyleng); return tk_dollar_ident;}
 {char} {TKSTRIPPEDRETURN(yytext,yyleng); return tk_char;}
 {b8_int} {TKRETURN(yytext,yyleng); return tk_integer;}


### PR DESCRIPTION
Escaped identifiers are allowed to end in a space, tab, newline or
formfeed. Currently, ADMS only recognises a space. This commit also
accommodates the remaining whitespace options.