### PR TITLE
Flag LRM-compliant output variables in adms data tree

### DIFF
--- a/admsXml/adms.implicit.xml
+++ b/admsXml/adms.implicit.xml
@@ -594,6 +594,15 @@
       <admst:value-to select="[name='type' and value='instance']/../parametertype" string="instance"/>
       <admst:value-to select="[name='ask' and value='yes']/../output" string="yes"/>
       <admst:value-to select="[name='ask' and value='no']/../output" string="no"/>
+      <!-- set output flag if desc or units attribute and we are a module-
+            scoped variable,  not an input parameter, and have 
+            desc or units attribute, per Verilog-A LRM 2.4, section 3.2.1 -->
+      <admst:if test="[../input!='yes' and ../module/name=../block/name and name='desc' and value!='']">
+          <admst:value-to select="../output" string="yes"/>
+      </admst:if>
+     <admst:if test="[../input!='yes' and ../module/name=../block/name and name='units' and value!='']">
+          <admst:value-to select="../output" string="yes"/>
+      </admst:if>
     </admst:for-each>
     <admst:apply-templates select="default" match="e:dependency"/>
     <admst:value-to


### PR DESCRIPTION
Per issue Qucs/ADMS#72, the implicit rules in adms.implicit.xml only flag a variable in the data tree with "output=yes" in the data tree if they have the attribute 'ask="yes"'.

The LRM (Verilog-AMS LRM version 2.4, section 3.2.1) says that module-scoped variables with either "desc" or "units" attributes should be designated as output variables.

This commit modifies adms.implicit.xml to set the "output" field of the data tree to "yes" if the variable is not an input variable (parameter) and is module scoped, and if it has either a "desc" or a "units" (or both) attribute.

The Xyce team has been using a patched adms.implicit.xml with this modification for a couple of years, and I had simply forgotten that I'd opened issue Qucs/ADMS#72 asking that it be done in ADMS itself.

Qucs/ADMS#72